### PR TITLE
Updating to comply with current jedi-vim interface

### DIFF
--- a/jedi-remote-command.py
+++ b/jedi-remote-command.py
@@ -3,6 +3,7 @@
 import json
 import sys
 import traceback
+import os
 
 
 class JSONRPC(object):
@@ -94,7 +95,8 @@ if __name__ == '__main__':
     if len(sys.argv) > 1:
         jedi_path = sys.argv[1]
         if jedi_path:
-            sys.path.append(jedi_path)
+            sys.path.append(os.path.join(jedi_path, 'jedi'))
+            sys.path.append(os.path.join(jedi_path, 'parso'))
 
     import jedi
 

--- a/jedi_remote.py
+++ b/jedi_remote.py
@@ -15,14 +15,14 @@ class JediRemote(object):
     '''
     python = 'python'
     remote_command = 'jedi-remote-command.py'
-    jedi_path = ''
+    jedi_pythonx_path = ''
 
-    def __init__(self, python=None, jedi_path=None):
+    def __init__(self, python=None, jedi_pythonx_path=None):
         if python is not None:
             self.python = python
 
-        if jedi_path is not None:
-            self.jedi_path = jedi_path
+        if jedi_pythonx_path is not None:
+            self.jedi_pythonx_path = jedi_pythonx_path
 
         self._process = None
 
@@ -38,7 +38,11 @@ class JediRemote(object):
             cmd = os.path.join(
                 os.path.dirname(
                     os.path.abspath(__file__)), self.remote_command)
-            self._process = Popen([self.python, cmd, self.jedi_path], stdin=PIPE, stdout=PIPE)
+            self._process = Popen(
+                [self.python, cmd, self.jedi_pythonx_path],
+                stdin=PIPE,
+                stdout=PIPE
+            )
 
         return self._process
 

--- a/jedi_remote.py
+++ b/jedi_remote.py
@@ -101,8 +101,6 @@ class JediRemote(object):
         else:
             return obj
 
-    NotFoundError = jedi.api.NotFoundError
-
 
 class RemoteObject(object):
     '''Remotely managed object

--- a/patch.py
+++ b/patch.py
@@ -6,14 +6,16 @@ import vim
 sys.path.insert(0, vim.eval('expand(s:script_path)'))
 
 python_executable = vim.vars.get('jedi_rpc#python')
-jedi_path = os.path.join(os.path.dirname(jedi_vim.__file__), 'jedi')
+jedi_pythonx_path = os.path.dirname(jedi_vim.__file__)
 
 try:
     import jedi_remote
 
     if not isinstance(jedi_vim.jedi, jedi_remote.JediRemote):
-        jedi_vim.jedi = jedi_remote.JediRemote(python_executable,
-                                               jedi_path=jedi_path)
+        jedi_vim.jedi = jedi_remote.JediRemote(
+            python_executable,
+            jedi_pythonx_path=jedi_pythonx_path
+        )
 
 finally:
     sys.path.pop(0)


### PR DESCRIPTION
* You may consider removing this exception. It is currently deprecated.
* Also, I provided a set of changes to use the version of `parso` shipped with `jedi-vim` if not available in the used python environment.

Nice plugin btw ;)